### PR TITLE
api/products.js: fixed routes where (/product) was appearing when it wasn't needed

### DIFF
--- a/api/products.js
+++ b/api/products.js
@@ -8,7 +8,7 @@ const {
   deleteProduct,
 } = require("../db");
 
-productsRouter.get("/products", async (req, res, next) => {
+productsRouter.get("/", async (req, res, next) => {
   try {
     const getProducts = await getAllProducts();
     res.send(getProducts);
@@ -17,7 +17,7 @@ productsRouter.get("/products", async (req, res, next) => {
   }
 });
 
-productsRouter.post("/products", async (req, res, next) => {
+productsRouter.post("/", async (req, res, next) => {
   try {
     const { name, description, price, stock, type } = req.body;
     const postProduct = await createProduct({
@@ -33,7 +33,7 @@ productsRouter.post("/products", async (req, res, next) => {
   }
 });
 
-productsRouter.patch("/products/:id", async (req, res, next) => {
+productsRouter.patch("/:id", async (req, res, next) => {
   try {
     const { id } = req.params;
     const { name, description, price, stock, type } = req.body;
@@ -52,7 +52,7 @@ productsRouter.patch("/products/:id", async (req, res, next) => {
   }
 });
 
-productsRouter.delete("/products/:id", async (req, res, next) => {
+productsRouter.delete("/:id", async (req, res, next) => {
   try {
     const { id } = req.params;
 


### PR DESCRIPTION
Updated api/products.js routes by removing "/products" as we don't need it.
![image](https://github.com/raynhlee/grace-shopper-capstone/assets/123019576/2c01b3e8-bbe5-454d-8e1f-7d9e08008041)
